### PR TITLE
Some things  found while looking for the APC shift problem

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -597,6 +597,9 @@ Proc for attack log creation, because really why not
 		target.log_message(reverse_message, LOG_ATTACK, color="orange", log_globally=FALSE)
 
 /atom/New(loc, ...)
+	if(GLOB.use_preloader && (src.type == GLOB._preloader.target_path))//in case the instanciated atom is creating other atoms in New()
+		GLOB._preloader.load(src)
+
 	var/do_initialize = SSatoms.initialized
 	if(do_initialize != INITIALIZATION_INSSATOMS)
 		args[1] = do_initialize == INITIALIZATION_INNEW_MAPLOAD

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -97,7 +97,7 @@ Class Procs:
 	name = "machinery"
 	icon = 'icons/obj/stationobjs.dmi'
 	var/stat = 0
-	var/emagged = 0
+	var/emagged = FALSE
 	var/use_power = IDLE_POWER_USE
 		//0 = dont run the auto
 		//1 = run auto, use idle
@@ -115,7 +115,7 @@ Class Procs:
 	var/manual = 0
 	var/global/gl_uid = 1
 	layer = OBJ_LAYER
-	var/machine_processing = 0 // whether the machine is busy and requires process() calls in scheduler.
+	var/machine_processing = FALSE // whether the machine is busy and requires process() calls in scheduler.
 
 	var/destructible = TRUE
 	var/damage = 0
@@ -138,6 +138,8 @@ Class Procs:
 	var/area/A = get_area(src)
 	if(A)
 		A.area_machines += src
+	start_processing()
+	//power_change()
 
 /obj/machinery/Destroy()
 	GLOB.machines -= src
@@ -149,12 +151,12 @@ Class Procs:
 
 /obj/machinery/proc/start_processing()
 	if(!machine_processing)
-		machine_processing = 1
+		machine_processing = TRUE
 		processing_machines += src
 
 /obj/machinery/proc/stop_processing()
 	if(machine_processing)
-		machine_processing = 0
+		machine_processing = FALSE
 		processing_machines -= src
 
 /obj/machinery/process()//If you dont use process or power why are you here

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -27,7 +27,7 @@
 
 /datum/parsed_map/proc/initTemplateBounds()
 	//var/list/obj/machinery/atmospherics/atmos_machines = list()
-	//var/list/obj/structure/cable/cables = list()
+	var/list/obj/structure/cable/cables = list()
 	var/list/atom/atoms = list()
 
 	var/list/turfs = block(	locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
@@ -39,9 +39,9 @@
 		atoms += B
 		for(var/A in B)
 			atoms += A
-			//if(istype(A, /obj/structure/cable))
-			//	cables += A
-			//	continue
+			if(istype(A, /obj/structure/cable))
+				cables += A
+				continue
 			//if(istype(A, /obj/machinery/atmospherics))
 			//	atmos_machines += A
 	//for(var/L in border)
@@ -49,7 +49,7 @@
 		//T.air_update_turf(TRUE) //calculate adjacent turfs along the border to prevent runtimes
 
 	SSatoms.InitializeAtoms(atoms)
-	//SSmachines.setup_template_powernets(cables)
+	SSmachines.setup_template_powernets(cables)
 	//SSair.setup_template_machinery(atmos_machines)
 
 /datum/map_template/proc/load_new_z()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -185,8 +185,6 @@
 		update_icon()
 		addtimer(CALLBACK(src, .proc/update), 5)
 
-	start_processing()
-
 /obj/machinery/power/apc/Destroy()
 	GLOB.apcs_list -= src
 
@@ -225,8 +223,7 @@
 
 		update_icon()
 		make_terminal()
-
-		update() //areas should be lit on startup
+		addtimer(CALLBACK(src, .proc/update), 5)
 
 		//Break few ACPs on the colony
 		if(!start_charge && is_ground_level(z) && prob(10))

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -36,11 +36,8 @@
 	if(panel_open)
 		to_chat(user, "<span class='notice'>The maintenance hatch is open.</span>")
 
-/obj/machinery/power/smes/New()
+/obj/machinery/power/smes/Initialize()
 	. = ..()
-	if(!powernet)
-		connect_to_network()
-
 	dir_loop:
 		for(var/d in cardinal)
 			var/turf/T = get_step(src, d)
@@ -52,10 +49,7 @@
 		stat |= BROKEN
 		return
 	terminal.master = src
-	if(!terminal.powernet)
-		terminal.connect_to_network()
 	update_icon()
-	start_processing()
 
 /obj/machinery/power/smes/Destroy()
 	if(terminal)


### PR DESCRIPTION
This isn't supposed to get merged, it's rather some things i found while perusing the code :

* code/game/atoms.dm : the preloader didn't act in `New()` (so called first pass) so atoms were instanciated without the right `vars` (e.g the APC, hence the south (default) shifting)
* code/game/machinery/machinery.dm : `start processing` for all machines, they will get cut on first process if they don't need it (legacy /tg behavior, your call with this)
* code/modules/mapping/map_template.dm : generates powernets on new z level loading (needed for hotloading maps, e.g away missions)
*  code/modules/power/apc.dm : light cleaning
*  code/modules/power/smes.dm : fix SMES being broken on startup